### PR TITLE
bug: fixing examples to serialize entire graph

### DIFF
--- a/examples/v1/tiny/tiny.go
+++ b/examples/v1/tiny/tiny.go
@@ -34,7 +34,7 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Printf("Graph with %d nodes and %d edges.\n", len(g.Graph.Nodes), len(g.Graph.Edges))
-	_, err = json.Marshal(g.Graph)
+	_, err = json.Marshal(g)
 	if err != nil {
 		fmt.Printf("error marshalling %s:%s\n", jsonFile, err)
 		os.Exit(1)

--- a/examples/v2/cars/cars.go
+++ b/examples/v2/cars/cars.go
@@ -36,7 +36,7 @@ func main() {
 	for _, g := range data.Graphs {
 		fmt.Printf("Graph with %d nodes and %d edges.\n", len(g.Nodes), len(g.Edges))
 	}
-	toprint, err := json.Marshal(data.Graphs)
+	toprint, err := json.Marshal(data)
 	if err != nil {
 		fmt.Printf("error marshalling %s:%s\n", jsonFile, err)
 		os.Exit(1)

--- a/examples/v2/hyper-directed/hyperdirected.go
+++ b/examples/v2/hyper-directed/hyperdirected.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	fmt.Printf("Graph with %d nodes and %d edges.\n", len(g.Graph.Nodes), len(g.Graph.Edges))
-	toprint, err := json.Marshal(g.Graph)
+	toprint, err := json.Marshal(g)
 	if err != nil {
 		fmt.Printf("error marshalling %s:%s\n", jsonFile, err)
 		os.Exit(1)

--- a/examples/v2/hyper-undirected/hyperundirected.go
+++ b/examples/v2/hyper-undirected/hyperundirected.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	fmt.Printf("Graph with %d nodes and %d edges.\n", len(g.Graph.Nodes), len(g.Graph.Edges))
-	toprint, err := json.Marshal(g.Graph)
+	toprint, err := json.Marshal(g)
 	if err != nil {
 		fmt.Printf("error marshalling %s:%s\n", jsonFile, err)
 		os.Exit(1)

--- a/examples/v2/miserables/miserables.go
+++ b/examples/v2/miserables/miserables.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	fmt.Printf("Graph with %d nodes and %d edges.\n", len(g.Graph.Nodes), len(g.Graph.Edges))
-	_, err = json.Marshal(g.Graph)
+	_, err = json.Marshal(g)
 	if err != nil {
 		fmt.Printf("error marshalling %s:%s\n", jsonFile, err)
 		os.Exit(1)

--- a/examples/v2/usual-suspects/usual-suspects.go
+++ b/examples/v2/usual-suspects/usual-suspects.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	fmt.Printf("Graph with %d nodes and %d edges.\n", len(g.Graph.Nodes), len(g.Graph.Edges))
-	toprint, err := json.Marshal(g.Graph)
+	toprint, err := json.Marshal(g)
 	if err != nil {
 		fmt.Printf("error marshalling %s:%s\n", jsonFile, err)
 		os.Exit(1)

--- a/jsongraph/v2/graph/types.go
+++ b/jsongraph/v2/graph/types.go
@@ -25,34 +25,34 @@ type GraphBase struct {
 	Directed bool            `json:"directed,omitempty" yaml:"directed,omitempty" mapstructure:"directed,omitempty"`
 	Type     string          `json:"type,omitempty" yaml:"type,omitempty" mapstructure:"type,omitempty"`
 	Nodes    map[string]Node `json:"nodes" yaml:"nodes" mapstructure:"nodes"`
-}
+} 
 
 // A JSONGraph can either be parsed into a list of graps or single graph
 // We have types for standard, and then explicitly directed and undirected
 type JsonGraph struct {
-	Graph Graph `json:"graph"`
+	Graph Graph `json:"graph" yaml:"graph" mapstructure:"graph"`
 }
 
 type JsonGraphList struct {
-	Graphs []Graph `json:"graphs"`
+	Graphs []Graph `json:"graphs" yaml:"graphs" mapstructure:"graphs"`
 }
 
 // DirectedJsonGraph is explicitly a directed graph
 type DirectedJsonGraph struct {
-	Graph DirectedGraph `json:"graph"`
+	Graph DirectedGraph `json:"graph" yaml:"graph" mapstructure:"graph"`
 }
 
 type DirectedJsonGraphList struct {
-	Graphs []DirectedGraph `json:"graphs"`
+	Graphs []DirectedGraph `json:"graphs" yaml:"graphs" mapstructure:"graphs"`
 }
 
 // UndirectedJsonGraph is explicitly an undirected graph
 type UndirectedJsonGraph struct {
-	Graph UndirectedGraph `json:"graph"`
+	Graph UndirectedGraph `json:"graph" yaml:"graph" mapstructure:"graph"`
 }
 
 type UndirectedJsonGraphList struct {
-	Graphs []UndirectedGraph `json:"graphs"`
+	Graphs []UndirectedGraph `json:"graphs" yaml:"graphs" mapstructure:"graphs"`
 }
 
 // New functions handle creation of new graphs (and directed, etc.)
@@ -80,7 +80,7 @@ func NewUndirectedGraph() *UndirectedJsonGraph {
 // A standard Json graph
 // - has a list of edges
 type Graph struct {
-	GraphBase
+	GraphBase 
 	Edges []Edge `json:"edges" yaml:"edges" mapstructure:"edges"`
 }
 


### PR DESCRIPTION
Problem: if we serialize the g.Graph we miss the top level graph
Solution: serialize the g instead!