### PR TITLE
feat: support to get named metadata field

### DIFF
--- a/examples/v1/tiny/tiny.go
+++ b/examples/v1/tiny/tiny.go
@@ -39,5 +39,4 @@ func main() {
 		fmt.Printf("error marshalling %s:%s\n", jsonFile, err)
 		os.Exit(1)
 	}
-
 }

--- a/jsongraph/metadata/metadata.go
+++ b/jsongraph/metadata/metadata.go
@@ -39,13 +39,23 @@ func (m *Metadata) GetStringElement(name string) (string, error) {
 	}
 	return element.(string), nil
 }
+
 func (m *Metadata) GetIntElement(name string) (int32, error) {
 	element, ok := m.lookup[name]
 	if !ok {
 		return -1, fmt.Errorf("integer element %s does not exist", name)
 	}
+	intValue, ok := element.(int)
+	if ok {
+		return int32(intValue), nil
+	}
+	floatValue, ok := element.(float64)
+	if ok {
+		return int32(floatValue), nil
+	}
 	return element.(int32), nil
 }
+
 func (m *Metadata) GetBoolElement(name string) (bool, error) {
 	element, ok := m.lookup[name]
 	if !ok {

--- a/jsongraph/metadata/metadata.go
+++ b/jsongraph/metadata/metadata.go
@@ -2,12 +2,17 @@ package metadata
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 )
 
 // Metadata is a basic map that can be used by any graph object
 type Metadata struct {
 	Elements []MetadataElement
+
+	// Lookup is explicitly for developers, so it is easy
+	// to find a known value (and type it correctly)
+	lookup map[string]interface{}
 }
 type MetadataElement struct {
 	Name    string
@@ -25,9 +30,40 @@ type MetadataElement struct {
 	IsBool    bool
 }
 
+// GetXElement will retrieve (and type) an element
+// This is intended for interacting with the struct in Go
+func (m *Metadata) GetStringElement(name string) (string, error) {
+	element, ok := m.lookup[name]
+	if !ok {
+		return "", fmt.Errorf("string element %s does not exist", name)
+	}
+	return element.(string), nil
+}
+func (m *Metadata) GetIntElement(name string) (int32, error) {
+	element, ok := m.lookup[name]
+	if !ok {
+		return -1, fmt.Errorf("integer element %s does not exist", name)
+	}
+	return element.(int32), nil
+}
+func (m *Metadata) GetBoolElement(name string) (bool, error) {
+	element, ok := m.lookup[name]
+	if !ok {
+		return false, fmt.Errorf("boolean element %s does not exist", name)
+	}
+	return element.(bool), nil
+}
+
 // AddElement adds an element to the metadata elements list
 // This can be used in the API or in the json Unmarshall function
 func (m *Metadata) AddElement(name string, raw any) {
+
+	if m.lookup == nil {
+		m.lookup = make(map[string]interface{})
+	}
+
+	// Add to global lookup
+	m.lookup[name] = raw
 	element := MetadataElement{Name: name}
 	value, ok := raw.(string)
 	if ok {


### PR DESCRIPTION
Problem: when read into go, we currently need to manually loop over metadata elements to find one.
Solution: store an interface lookup that can be indexed directly with specific functions for each type.